### PR TITLE
bug UnboundLocalError

### DIFF
--- a/src/Playground.ipynb
+++ b/src/Playground.ipynb
@@ -740,7 +740,7 @@
     "\n",
     "ax.set_yticks([])\n",
     "plt.tight_layout()\n",
-    "plt.show()"
+    "plt.show()\n"
    ]
   },
   {


### PR DESCRIPTION
# 症状
```bash
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
/tmp/ipykernel_2869/4182338255.py in <module>
     54 
     55 # Generate adversarial examples
---> 56 df_adv_lpf = gen_adv(config, 'LowProFool')
     57 df_adv_df = gen_adv(config, 'Deepfool')
     58 config['AdvData'] = {'LowProFool' : df_adv_lpf, 'Deepfool' : df_adv_df}

/tmp/ipykernel_2869/1201834468.py in gen_adv(config, method)
      9     # デバッグ
     10     print("Feature names:", feature_names)
---> 11     print("Encoded bounds keys:", list(encoded_bounds.keys()))
     12     print("Do feature names match encoded bounds?", set(feature_names) == set(encoded_bounds.keys()))
     13 

UnboundLocalError: local variable 'encoded_bounds' referenced before assignment
```

# 解決方法
このエラーメッセージ（UnboundLocalError: local variable 'encoded_bounds' referenced before assignment）は、encoded_bounds 変数が使用される前に定義されていないことを示しています。
これは、encoded_bounds の定義が print 文の後に来ているか、あるいは何らかの条件分岐によって encoded_bounds が定義されない可能性があることを示唆しています。
この問題を解決するために、gen_adv 関数を以下のように修正してみましょう：
```python
def gen_adv(config, method):
    df_test = config['TestData']
    feature_names = config['FeatureNames']
    extra_cols = ['orig_pred', 'adv_pred', 'iters']    
    model = config['Model']
    weights = config['Weights']
    bounds = config['Bounds']

    # encoded_bounds の定義をここに移動
    encoded_bounds = {}
    for feature, info in bounds.items():
        if info['type'] == 'numeric':
            encoded_bounds[feature] = info
        elif info['type'] == 'categorical':
            for value in info['values']:
                encoded_bounds[f"{feature}_{value}"] = {'type': 'numeric', 'min':0, 'max':1}

    # デバッグ出力
    print("Number of features:", len(feature_names))
    print("Length of weights:", len(weights))
    print("Number of encoded bounds:", len(encoded_bounds))
    print("Feature names:", feature_names)
    print("Encoded bounds keys:", list(encoded_bounds.keys()))
    print("Do feature names match encoded bounds?", set(feature_names) == set(encoded_bounds.keys()))

    maxiters = config['MaxIters']
    alpha = config['Alpha']
    lambda_ = config['Lambda']
    
    results = np.zeros((len(df_test), len(feature_names) + len(extra_cols)))

    # ... (残りのコード)
```
この修正により：

1. encoded_bounds の定義が関数の先頭近くに移動され、確実に定義されます。
2. デバッグ用の print 文が encoded_bounds の定義後に配置されます。

これらの変更を適用した後、再度実行してみてください。新たなエラーが発生した場合や、予期せぬ結果が出た場合は、そのエラーメッセージまたは出力を共有してください。また、デバッグ出力の結果も確認し、特徴量の数、重みの数、エンコードされた境界の数が一致しているかどうかを確認してください。